### PR TITLE
Implement slash commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -301,7 +301,7 @@ class Mail(commands.Cog):
             )
 
         try:
-            await utils._trigger_create_thread(
+            await utils._trigger_create_user_thread(
                 self.bot,
                 member,
                 ctx.message,
@@ -631,10 +631,10 @@ class Mail(commands.Cog):
 
             else:
                 try:
-                    thread = await utils._trigger_create_thread(self.bot, message.author, message, 'user')
+                    thread = await utils._trigger_create_user_thread(self.bot, message.author, message, 'user')
                 except RuntimeError as e:
                     logging.critical(
-                        f'Exception thrown when calling utils._trigger_create_thread() with user {message.author.id}: %s',
+                        f'Exception thrown when calling utils._trigger_create_user_thread() with user {message.author.id}: %s',
                         e,
                     )
                     return

--- a/bot.py
+++ b/bot.py
@@ -9,9 +9,9 @@ from sys import exit
 import discord
 import pymongo
 from discord.ext import commands
-from discord_slash import SlashCommand, cog_ext, SlashContext
-from discord_slash.utils.manage_commands import create_option, create_permission
+from discord_slash import SlashCommand, SlashContext, cog_ext
 from discord_slash.model import SlashCommandOptionType, SlashCommandPermissionType
+from discord_slash.utils.manage_commands import create_option, create_permission
 
 import utils
 

--- a/bot.py
+++ b/bot.py
@@ -31,7 +31,11 @@ mclient = pymongo.MongoClient(config.mongoHost, username=config.mongoUser, passw
 intents = discord.Intents(guilds=True, members=True, bans=True, messages=True, typing=True)
 activityStatus = discord.Activity(type=discord.ActivityType.playing, name='DM to contact mods')
 bot = commands.Bot(
-    config.command_prefixes, fetch_offline_members=True, activity=activityStatus, case_insensitive=True, intents=intents
+    command_prefix=commands.when_mentioned,
+    fetch_offline_members=True,
+    activity=activityStatus,
+    case_insensitive=True,
+    intents=intents,
 )
 slash = SlashCommand(bot)
 guildList = [config.guild]

--- a/bot.py
+++ b/bot.py
@@ -237,26 +237,21 @@ class Mail(commands.Cog):
                 description='The user to start a thread with',
                 option_type=SlashCommandOptionType.USER,
                 required=True,
-            ),
-            create_option(
-                name='content',
-                description='The message to send to the user',
-                option_type=SlashCommandOptionType.STRING,
-                required=True,
-            ),
+            )
         ],
     )
     async def _open_thread(self, ctx: SlashContext, member, *, content):
         """
         Open a modmail thread with a user
         """
+        await ctx.defer()
         if mclient.modmail.logs.find_one({'recipient.id': str(member.id), 'open': True}):
             return await ctx.send(
                 ':x: Unable to open modmail to user -- there is already a thread involving them currently open'
             )
 
         try:
-            await utils._trigger_create_thread(
+            await utils._trigger_create_mod_thread(
                 self.bot,
                 member,
                 ctx.message,
@@ -282,26 +277,21 @@ class Mail(commands.Cog):
                 description='The user to start a thread with',
                 option_type=SlashCommandOptionType.USER,
                 required=True,
-            ),
-            create_option(
-                name='content',
-                description='The message to send to the user',
-                option_type=SlashCommandOptionType.STRING,
-                required=True,
-            ),
+            )
         ],
     )
     async def _open_thread_anon(self, ctx: SlashContext, member, *, content):
         """
         Open a modmail thread with a user anonymously
         """
+        await ctx.defer()
         if mclient.modmail.logs.find_one({'recipient.id': str(member.id), 'open': True}):
             return await ctx.send(
                 ':x: Unable to open modmail to user -- there is already a thread involving them currently open'
             )
 
         try:
-            await utils._trigger_create_user_thread(
+            await utils._trigger_create_mod_thread(
                 self.bot,
                 member,
                 ctx.message,

--- a/bot.py
+++ b/bot.py
@@ -39,6 +39,7 @@ bot = commands.Bot(
 )
 slash = SlashCommand(bot)
 guildList = [config.guild]
+modPermissions = {config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]}
 
 
 class Mail(commands.Cog):
@@ -53,7 +54,7 @@ class Mail(commands.Cog):
         name='close',
         guild_ids=guildList,
         description='Closes a modmail thread, optionally with a delay',
-        permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
+        permissions=modPermissions,
         options=[
             create_option(
                 name='delay',
@@ -102,7 +103,7 @@ class Mail(commands.Cog):
         name='reply',
         guild_ids=guildList,
         description='Replys to a modmail, with your username',
-        permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
+        permissions=modPermissions,
         options=[
             create_option(
                 name='content',
@@ -123,7 +124,7 @@ class Mail(commands.Cog):
         name='areply',
         guild_ids=guildList,
         description='Replys to a modmail, anonymously',
-        permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
+        permissions=modPermissions,
         options=[
             create_option(
                 name='content',
@@ -239,7 +240,7 @@ class Mail(commands.Cog):
         name='open',
         guild_ids=guildList,
         description='Open a modmail thread with a user, using your username',
-        permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
+        permissions=modPermissions,
         options=[
             create_option(
                 name='member',
@@ -290,7 +291,7 @@ class Mail(commands.Cog):
         guild_ids=guildList,
         base_description='Make a decision to accept or deny a ban appeal',
         description='Accept a user\'s ban appeal',
-        base_permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
+        base_permissions=modPermissions,
         options=[
             create_option(
                 name='reason',
@@ -370,7 +371,7 @@ class Mail(commands.Cog):
         guild_ids=guildList,
         base_description='Make a decision to accept or deny a ban appeal',
         description='Deny a user\'s ban appeal',
-        base_permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
+        base_permissions=modPermissions,
         options=[
             create_option(
                 name='next_attempt',

--- a/bot.py
+++ b/bot.py
@@ -240,7 +240,7 @@ class Mail(commands.Cog):
             )
         ],
     )
-    async def _open_thread(self, ctx: SlashContext, member, *, content):
+    async def _open_thread(self, ctx: SlashContext, member):
         """
         Open a modmail thread with a user
         """
@@ -257,48 +257,7 @@ class Mail(commands.Cog):
                 ctx.message,
                 open_type='moderator',
                 moderator=ctx.author,
-                content=content,
                 anonymous=False,
-            )
-
-        except discord.Forbidden:
-            return
-
-        await ctx.send(f':white_check_mark: Modmail has been opened with {member}')
-
-    @cog_ext.cog_slash(
-        name='aopen',
-        guild_ids=guildList,
-        description='Open a modmail thread with a user, anonymously',
-        permissions={config.guild: [create_permission(config.modRole, SlashCommandPermissionType.ROLE, True)]},
-        options=[
-            create_option(
-                name='member',
-                description='The user to start a thread with',
-                option_type=SlashCommandOptionType.USER,
-                required=True,
-            )
-        ],
-    )
-    async def _open_thread_anon(self, ctx: SlashContext, member, *, content):
-        """
-        Open a modmail thread with a user anonymously
-        """
-        await ctx.defer()
-        if mclient.modmail.logs.find_one({'recipient.id': str(member.id), 'open': True}):
-            return await ctx.send(
-                ':x: Unable to open modmail to user -- there is already a thread involving them currently open'
-            )
-
-        try:
-            await utils._trigger_create_mod_thread(
-                self.bot,
-                member,
-                ctx.message,
-                open_type='moderator',
-                moderator=ctx.author,
-                content=content,
-                anonymous=True,
             )
 
         except discord.Forbidden:

--- a/bot.py
+++ b/bot.py
@@ -251,14 +251,7 @@ class Mail(commands.Cog):
             )
 
         try:
-            await utils._trigger_create_mod_thread(
-                self.bot,
-                member,
-                ctx.message,
-                open_type='moderator',
-                moderator=ctx.author,
-                anonymous=False,
-            )
+            await utils._trigger_create_mod_thread(self.bot, ctx.guild, member, ctx.author)
 
         except discord.Forbidden:
             return

--- a/bot.py
+++ b/bot.py
@@ -186,7 +186,7 @@ class Mail(commands.Cog):
             {
                 '$push': {
                     'messages': {
-                        'timestamp': str(ctx.message.created_at),
+                        'timestamp': str(datetime.datetime.utcnow().isoformat(sep=' ')),
                         'message_id': str(ctx.message.id),
                         'content': content if content else '',
                         'type': 'thread_message' if not anonymous else 'anonymous',

--- a/bot.py
+++ b/bot.py
@@ -136,10 +136,12 @@ class Mail(commands.Cog):
     async def _reply(self, ctx, content, anonymous=False):
         db = mclient.modmail.logs
         doc = db.find_one({'channel_id': str(ctx.channel.id)})
-        attachments = [x.url for x in ctx.message.attachments]
+        # Attachments are unable to be sent mod -> user with slash commands (unless it's a url).
+        #
+        # attachments = [x.url for x in ctx.message.attachments]
 
-        if not content and not attachments:
-            return await ctx.send('You must provide reply content, attachments, or both to use this command')
+        # if not content and not attachments:
+        #    return await ctx.send('You must provide reply content, attachments, or both to use this command')
 
         if ctx.channel.category_id != config.category or not doc:  # No thread in channel, or not in modmail category
             return await ctx.send('Cannot send a reply here, this is not a modmail channel!')
@@ -171,8 +173,8 @@ class Mail(commands.Cog):
             await member.send(
                 f'Reply from **{"Moderator" if anonymous else ctx.author}**: {content if content else ""}'
             )
-            if attachments:
-                await member.send('\n'.join(attachments))
+            # if attachments:
+            #    await member.send('\n'.join(attachments))
 
         except:
             return await ctx.send(
@@ -194,8 +196,8 @@ class Mail(commands.Cog):
                             'discriminator': ctx.author.discriminator,
                             'avatar_url': str(ctx.author.avatar_url_as(static_format='png', size=1024)),
                             'mod': True,
-                        },
-                        'attachments': attachments,
+                        }  # ,
+                        #'attachments': attachments,
                     }
                 }
             },
@@ -212,17 +214,17 @@ class Mail(commands.Cog):
                 icon_url='https://cdn.mattbsg.xyz/rns/snoo.png',
             )
 
-        if len(attachments) > 1:  # More than one attachment, use fields
-            for x in range(len(attachments)):
-                embed.add_field(name=f'Attachment {x + 1}', value=attachments[x])
-
-        elif attachments and re.search(
-            r'\.(gif|jpe?g|tiff|png|webp|bmp)$', str(attachments[0]), re.IGNORECASE
-        ):  # One attachment, image
-            embed.set_image(url=attachments[0])
-
-        elif attachments:  # Still have an attachment, but not an image
-            embed.add_field(name=f'Attachment', value=attachments[0])
+        #        if len(attachments) > 1:  # More than one attachment, use fields
+        #            for x in range(len(attachments)):
+        #                embed.add_field(name=f'Attachment {x + 1}', value=attachments[x])
+        #
+        #        elif attachments and re.search(
+        #            r'\.(gif|jpe?g|tiff|png|webp|bmp)$', str(attachments[0]), re.IGNORECASE
+        #        ):  # One attachment, image
+        #            embed.set_image(url=attachments[0])
+        #
+        #        elif attachments:  # Still have an attachment, but not an image
+        #            embed.add_field(name=f'Attachment', value=attachments[0])
 
         await ctx.send(embed=embed)
 

--- a/bot.py
+++ b/bot.py
@@ -181,28 +181,6 @@ class Mail(commands.Cog):
                 'There was an issue replying to this user, they may have left the server or disabled DMs'
             )
 
-        db.update_one(
-            {'_id': doc['_id']},
-            {
-                '$push': {
-                    'messages': {
-                        'timestamp': str(datetime.datetime.utcnow().isoformat(sep=' ')),
-                        'message_id': str(ctx.message.id),
-                        'content': content if content else '',
-                        'type': 'thread_message' if not anonymous else 'anonymous',
-                        'author': {
-                            'id': str(ctx.author.id),
-                            'name': ctx.author.name,
-                            'discriminator': ctx.author.discriminator,
-                            'avatar_url': str(ctx.author.avatar_url_as(static_format='png', size=1024)),
-                            'mod': True,
-                        }  # ,
-                        #'attachments': attachments,
-                    }
-                }
-            },
-        )
-
         embed = discord.Embed(title='Moderator message', description=content, color=0x7ED321)
         if not anonymous:
             embed.set_author(name=f'{ctx.author} ({ctx.author.id})', icon_url=ctx.author.avatar_url)
@@ -226,7 +204,29 @@ class Mail(commands.Cog):
         #        elif attachments:  # Still have an attachment, but not an image
         #            embed.add_field(name=f'Attachment', value=attachments[0])
 
-        await ctx.send(embed=embed)
+        mailMsg = await ctx.send(embed=embed)
+
+        db.update_one(
+            {'_id': doc['_id']},
+            {
+                '$push': {
+                    'messages': {
+                        'timestamp': str(datetime.datetime.utcnow().isoformat(sep=' ')),
+                        'message_id': str(mailMsg.id),
+                        'content': content if content else '',
+                        'type': 'thread_message' if not anonymous else 'anonymous',
+                        'author': {
+                            'id': str(ctx.author.id),
+                            'name': ctx.author.name,
+                            'discriminator': ctx.author.discriminator,
+                            'avatar_url': str(ctx.author.avatar_url_as(static_format='png', size=1024)),
+                            'mod': True,
+                        }  # ,
+                        #'attachments': attachments,
+                    }
+                }
+            },
+        )
 
     @cog_ext.cog_slash(
         name='open',

--- a/config.example.py
+++ b/config.example.py
@@ -2,7 +2,6 @@
 
 # Discord.py
 token = 'token'
-command_prefixes = ['!', ',', 'p']
 
 # Mongo Credentials
 mongoUser = 'user'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ discord.py
 pymongo
 jishaku
 pylint
+discord-py-slash-command

--- a/utils.py
+++ b/utils.py
@@ -355,7 +355,7 @@ async def _trigger_create_user_thread(
     return channel
 
 
-async def _trigger_create_mod_thread(self, bot, guild, member, moderator):
+async def _trigger_create_mod_thread(bot, guild, member, moderator):
     db = mclient.modmail.logs
     punsDB = mclient.bowser.puns
 

--- a/utils.py
+++ b/utils.py
@@ -377,7 +377,7 @@ async def _trigger_create_mod_thread(bot, guild, member, moderator):
 
     threadCount = db.count_documents({'recipient.id': str(member.id)})
     docID = await _create_thread(
-        bot, channel, moderator, member, created_at=datetime.datetime.utcnow().isoformat(sep=' ')
+        bot, channel, moderator, member, created_at=str(datetime.datetime.utcnow().isoformat(sep=' '))
     )  # Since we don't have a reference with slash commands, pull current iso datetime in UTC
 
     punsDB = mclient.bowser.puns

--- a/utils.py
+++ b/utils.py
@@ -406,6 +406,13 @@ async def _trigger_create_mod_thread(self, bot, guild, member, moderator, anonym
         )
         raise
 
+    embed = discord.Embed(
+        title='Thread is open',
+        description='This thread is now open to moderator and user replies. Start the conversation by using `/reply` or `/areply`',
+        color=0x58B9FF,
+    )
+    await channel.send(embed=embed)
+
 
 async def _info(ctx, bot, user: typing.Union[discord.Member, int]):
     inServer = True

--- a/utils.py
+++ b/utils.py
@@ -401,13 +401,11 @@ async def _trigger_create_mod_thread(bot, guild, member, moderator):
 
     embed.description = description
     mailMsg = await channel.send(embed=embed)
-    await _info(await bot.get_context(mailMsg), bot, guild.fetch_member(member.id))
+    await _info(await bot.get_context(mailMsg), bot, await guild.fetch_member(member.id))
     try:
         await member.send(
             f'Hi there!\nThe chat moderators who oversee the **{guild.name}** Discord have opened a modmail with you!\n\nI will send you a message when a moderator responds to this thread. Every message you send to me while your thread is open will also be sent to the moderation team -- so you can message me anytime to add information or to reply to a moderator\'s message. You\'ll know your message has been sent when I react to your message with a ✅.'
         )
-
-        await channel.send(embed=embed)
 
     except discord.Forbidden:
         # Cleanup if there really was an issue messaging the user, i.e. bot blocked

--- a/utils.py
+++ b/utils.py
@@ -128,7 +128,16 @@ async def _can_appeal(member):
 
 
 async def _create_thread(
-    bot, channel, creator, recipient, is_mention=False, content=None, is_mod=False, ban_appeal=False, message=None
+    bot,
+    channel,
+    creator,
+    recipient,
+    is_mention=False,
+    content=None,
+    is_mod=False,
+    ban_appeal=False,
+    messsage=None,
+    created_at=None,
 ):
     db = mclient.modmail.logs
     initial_message = None
@@ -151,6 +160,7 @@ async def _create_thread(
         }
 
         _id = str(message.id) + '-' + str(int(time.time()))
+        created_at = str(message.created_at)
 
     else:
         _id = str(channel.id) + '-' + str(int(time.time()))
@@ -160,7 +170,7 @@ async def _create_thread(
             '_id': _id,
             'key': _id,
             'open': True,
-            'created_at': str(message.created_at),
+            'created_at': created_at,
             'closed_at': None,
             'channel_id': str(channel.id),
             'guild_id': str(channel.guild.id),
@@ -345,7 +355,7 @@ async def _trigger_create_user_thread(
     return channel
 
 
-async def _trigger_create_mod_thread(self, bot, guild, member, moderator, anonymous):
+async def _trigger_create_mod_thread(self, bot, guild, member, moderator):
     db = mclient.modmail.logs
     punsDB = mclient.bowser.puns
 
@@ -366,7 +376,9 @@ async def _trigger_create_mod_thread(self, bot, guild, member, moderator, anonym
     embed.set_author(name=f'{member} ({member.id})', icon_url=member.avatar_url)
 
     threadCount = db.count_documents({'recipient.id': str(member.id)})
-    docID = await _create_thread(bot, channel, moderator, member)
+    docID = await _create_thread(
+        bot, channel, moderator, member, created_at=datetime.datetime.utcnow().isoformat(sep=' ')
+    )  # Since we don't have a reference with slash commands, pull current iso datetime in UTC
 
     punsDB = mclient.bowser.puns
     puns = punsDB.find({'user': member.id, 'active': True})

--- a/utils.py
+++ b/utils.py
@@ -136,7 +136,7 @@ async def _create_thread(
     content=None,
     is_mod=False,
     ban_appeal=False,
-    messsage=None,
+    message=None,
     created_at=None,
 ):
     db = mclient.modmail.logs

--- a/utils.py
+++ b/utils.py
@@ -128,11 +128,32 @@ async def _can_appeal(member):
 
 
 async def _create_thread(
-    bot, channel, message, creator, recipient, is_mention, content=None, is_mod=False, ban_appeal=False
+    bot, channel, creator, recipient, is_mention=False, content=None, is_mod=False, ban_appeal=False, message=None
 ):
     db = mclient.modmail.logs
-    _id = str(message.id) + '-' + str(int(time.time()))
-    attachments = [x.url for x in message.attachments]
+    initial_message = None
+    if message:
+        attachments = [x.url for x in message.attachments]
+        initial_message = {
+            'timestamp': str(message.created_at),
+            'message_id': str(message.id),
+            'content': message.content if not content else content,
+            'type': 'mention' if is_mention else 'thread_message',
+            'author': {
+                'id': str(message.author.id),
+                'name': message.author.name,
+                'discriminator': message.author.discriminator,
+                'avatar_url': str(message.author.avatar_url_as(static_format='png', size=1024)),
+                'mod': is_mod,
+            },
+            'attachments': attachments,
+            'channel': {'id': str(message.channel.id), 'name': message.channel.name} if is_mention else {},
+        }
+
+        _id = str(message.id) + '-' + str(int(time.time()))
+
+    else:
+        _id = str(channel.id) + '-' + str(int(time.time()))
 
     db.insert_one(
         {
@@ -160,23 +181,7 @@ async def _create_thread(
                 'mod': False,
             },
             'closer': None,
-            'messages': [
-                {
-                    'timestamp': str(message.created_at),
-                    'message_id': str(message.id),
-                    'content': message.content if not content else content,
-                    'type': 'mention' if is_mention else 'thread_message',
-                    'author': {
-                        'id': str(message.author.id),
-                        'name': message.author.name,
-                        'discriminator': message.author.discriminator,
-                        'avatar_url': str(message.author.avatar_url_as(static_format='png', size=1024)),
-                        'mod': is_mod,
-                    },
-                    'attachments': attachments,
-                    'channel': {'id': str(message.channel.id), 'name': message.channel.name} if is_mention else {},
-                }
-            ],
+            'messages': [] if not initial_message else [initial_message],
         }
     )
 
@@ -231,7 +236,7 @@ async def _close_thread(bot, ctx, target_channel, dm=True, reason=None):
     await target_channel.send(embed=embed)
 
 
-async def _trigger_create_thread(
+async def _trigger_create_user_thread(
     bot, member, message, open_type, is_mention=False, moderator=None, content=None, anonymous=True
 ):
     db = mclient.modmail.logs
@@ -289,13 +294,13 @@ async def _trigger_create_thread(
     docID = await _create_thread(
         bot,
         channel,
-        message,
         member if not moderator else moderator,
         member,
         is_mention,
         content=None if not content else content,
         is_mod=True if moderator else False,
         ban_appeal=banAppeal,
+        message=message,
     )
 
     punsDB = mclient.bowser.puns
@@ -332,58 +337,74 @@ async def _trigger_create_thread(
             f'Hi there!\nYou have submitted a ban appeal to the chat moderators who oversee the **{guild.name}** Discord.\n\nI will send you a message when a moderator responds to this thread. Every message you send to me while your thread is open will also be sent to the moderation team -- so you can message me anytime to add information or to reply to a moderator\'s message. You\'ll know your message has been sent when I react to your message with a ✅.\n\nPlease be patient for a response; the moderation team will have active discussions about the appeal and may take some time to reply. We ask that you be civil and respectful during this process so constructive conversation can be had in both directions. At the end of this process, moderators will either lift or uphold your ban -- you will receive an official message stating the final decision.'
         )
 
-    elif open_type == 'moderator':
-        try:
-            attachments = [x.url for x in message.attachments]
-            await member.send(
-                f'Hi there!\nThe chat moderators who oversee the **{guild.name}** Discord have opened a modmail with you!\n\nI will send you a message when a moderator responds to this thread. Every message you send to me while your thread is open will also be sent to the moderation team -- so you can message me anytime to add information or to reply to a moderator\'s message. You\'ll know your message has been sent when I react to your message with a ✅.'
-            )
-            await member.send(
-                f'Message from **{"Moderator" if anonymous else message.author}**: {content if content else ""}'
-            )
-            if attachments:
-                await member.send('\n'.join(attachments))
-
-            embed = discord.Embed(title='Moderator message', description=content, color=0x7ED321)
-            if not anonymous:
-                embed.set_author(name=f'{moderator} ({moderator.id})', icon_url=moderator.avatar_url)
-
-            else:
-                embed.title = '[ANON] Moderator message'
-                embed.set_author(
-                    name=f'{moderator} ({moderator.id}) as r/NintendoSwitch',
-                    icon_url='https://cdn.mattbsg.xyz/rns/snoo.png',
-                )
-
-            if len(attachments) > 1:  # More than one attachment, use fields
-                for x in range(len(attachments)):
-                    embed.add_field(name=f'Attachment {x + 1}', value=attachments[x])
-
-            elif attachments and re.search(
-                r'\.(gif|jpe?g|tiff|png|webp|bmp)$', str(attachments[0]), re.IGNORECASE
-            ):  # One attachment, image
-                embed.set_image(url=attachments[0])
-
-            elif attachments:  # Still have an attachment, but not an image
-                embed.add_field(name=f'Attachment', value=attachments[0])
-
-            await channel.send(embed=embed)
-
-        except discord.Forbidden:
-            # Cleanup if there really was an issue messaging the user, i.e. bot blocked
-            db.delete_one({'_id': docID})
-            await channel.delete()
-            await bot.get_channel(config.adminChannel).send(
-                f'Failed to DM {member.mention} for modmail thread created by {moderator.mention}. Thread open action canceled'
-            )
-            raise
-
     else:
         await member.send(
             f'Hi there!\nYou have opened a modmail thread with the chat moderators who oversee the **{guild.name}** Discord and they have received your message.\n\nI will send you a message when moderators respond to this thread. Every message you send to me while your thread is open will also be sent to the moderation team -- so you can message me anytime to add information or to reply to a moderator\'s message. You\'ll know your message has been sent when I react to your message with a ✅. \n\nPlease be patient for a response; if this is an urgent issue you may also ping the Chat-Mods with @Chat-Mods in a channel'
         )
 
     return channel
+
+
+async def _trigger_create_mod_thread(self, bot, guild, member, moderator, anonymous):
+    db = mclient.modmail.logs
+    punsDB = mclient.bowser.puns
+
+    guild = bot.get_guild(config.guild)
+    appealGuild = bot.get_guild(config.appealGuild)
+    try:
+        await guild.fetch_member(member.id)
+
+    except discord.NotFound:
+        raise RuntimeError('Invalid user')  # TODO: We need custom exceptions
+
+    category = guild.get_channel(config.category)
+    channelName = f'{member.name}-{member.discriminator}'
+    channel = await category.create_text_channel(channelName, reason='New modmail opened')
+
+    embed = discord.Embed(title='New modmail opened', color=0xE3CF59)
+
+    embed.set_author(name=f'{member} ({member.id})', icon_url=member.avatar_url)
+
+    threadCount = db.count_documents({'recipient.id': str(member.id)})
+    docID = await _create_thread(bot, channel, moderator, member)
+
+    punsDB = mclient.bowser.puns
+    puns = punsDB.find({'user': member.id, 'active': True})
+    punsCnt = punsDB.count_documents({'user': member.id, 'active': True})
+
+    description = f'A modmail thread has been opened with {member} ({member.mention}) by {moderator} ({moderator.mention}). There are {threadCount} previous threads involving this user'
+    description += f'. Archive link: {config.logUrl}{docID}'
+
+    if punsCnt:
+        description += '\n\n__User has active punishments:__\n'
+        for pun in puns:
+            timestamp = datetime.datetime.utcfromtimestamp(pun['timestamp']).strftime('%b %d, %y at %H:%M UTC')
+            if pun['type'] == 'strike':
+                description += f"**{punNames[pun['type']].format(pun['active_strike_count'], 's' if pun['active_strike_count'] > 1 else '')}** by <@{pun['moderator']}> on {timestamp}\n    ･ {pun['reason']}\n"
+
+            else:
+                description += (
+                    f"**{punNames[pun['type']]}** by <@{pun['moderator']}> on {timestamp}\n    ･ {pun['reason']}\n"
+                )
+
+    embed.description = description
+    mailMsg = await channel.send(embed=embed)
+    await _info(guild.fetch_member(member.id))
+    try:
+        await member.send(
+            f'Hi there!\nThe chat moderators who oversee the **{guild.name}** Discord have opened a modmail with you!\n\nI will send you a message when a moderator responds to this thread. Every message you send to me while your thread is open will also be sent to the moderation team -- so you can message me anytime to add information or to reply to a moderator\'s message. You\'ll know your message has been sent when I react to your message with a ✅.'
+        )
+
+        await channel.send(embed=embed)
+
+    except discord.Forbidden:
+        # Cleanup if there really was an issue messaging the user, i.e. bot blocked
+        db.delete_one({'_id': docID})
+        await channel.delete()
+        await bot.get_channel(config.adminChannel).send(
+            f'Failed to DM {member.mention} for modmail thread created by {moderator.mention}. Thread open action canceled'
+        )
+        raise
 
 
 async def _info(ctx, bot, user: typing.Union[discord.Member, int]):

--- a/utils.py
+++ b/utils.py
@@ -401,7 +401,7 @@ async def _trigger_create_mod_thread(bot, guild, member, moderator):
 
     embed.description = description
     mailMsg = await channel.send(embed=embed)
-    await _info(guild.fetch_member(member.id))
+    await _info(await bot.get_context(mailMsg), bot, guild.fetch_member(member.id))
     try:
         await member.send(
             f'Hi there!\nThe chat moderators who oversee the **{guild.name}** Discord have opened a modmail with you!\n\nI will send you a message when a moderator responds to this thread. Every message you send to me while your thread is open will also be sent to the moderation team -- so you can message me anytime to add information or to reply to a moderator\'s message. You\'ll know your message has been sent when I react to your message with a ✅.'

--- a/utils.py
+++ b/utils.py
@@ -204,7 +204,7 @@ async def _close_thread(bot, ctx, target_channel, dm=True, reason=None):
     closeInfo = {
         '$set': {
             'open': False,
-            'closed_at': str(ctx.message.created_at),
+            'closed_at': datetime.datetime.utcnow().isoformat(sep=' '),
             'closer': {
                 'id': str(ctx.author.id),
                 'name': ctx.author.name,
@@ -377,7 +377,7 @@ async def _trigger_create_mod_thread(bot, guild, member, moderator):
 
     threadCount = db.count_documents({'recipient.id': str(member.id)})
     docID = await _create_thread(
-        bot, channel, moderator, member, created_at=str(datetime.datetime.utcnow().isoformat(sep=' '))
+        bot, channel, moderator, member, created_at=datetime.datetime.utcnow().isoformat(sep=' ')
     )  # Since we don't have a reference with slash commands, pull current iso datetime in UTC
 
     punsDB = mclient.bowser.puns


### PR DESCRIPTION
# Pull request template
Use this template for all contributions made for the repository.

Please indicate all that apply with a checkmark. To make a check, convert brackets below to `[x]`.

* [x] **Feature implementation**
* [x] **Bug fix**
* [ ] **Code change/improvement**
* [x] **String change (i.e. grammar/spelling error or an addition)**

***

## Describe what your pull request does
This PR implements slash commands in Parakarry. Text commands have been entirely superseded by native slash commands in this release. As a side-effect the following function changes are now present:
* Text commands no longer function; slash commands are the new sole interaction method with the bot via Discord
* The flow for creating modmail threads with a user has changed.
    * `!aopen` and `!open` commands have been combined into a single `/open` command
    * `/open` No longer takes a message argument. Instead, it only opens a thread and notifies the user a thread has been opened with them
    * The moderator will need to send their reply via `/areply` or `/reply` after opening a thread in that threads channel 
![](https://cdn.mattbsg.xyz/ZwiBsYdw8n.png)
![](https://cdn.mattbsg.xyz/V1HfqjcFBY.png)
* Moderators can no longer directly send attachments in the same message as a reply -- this is a limitation with Discord
    * An alternative is upload the image in the thread channel then reply the link to the user


## Related issues and extra details
https://trello.com/c/LzEA1HOT/163-slash-command-components-threads-migration
