### PR TITLE
Remove broken mention func, replace w/ on cmd err

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -272,23 +272,6 @@ class Mail(commands.Cog):
 
         await ctx.send(f':white_check_mark: Modmail has been opened with {member}')
 
-    @commands.has_any_role(config.modRole)
-    @commands.group(name='s', aliases=['snippet', 'snippets'])
-    async def _snippets(self, ctx, *args):
-        db = mclient.modlog.snippets
-        if not args:
-            tagList = []
-            for x in db.find({}):
-                tagList.append(x['_id'])
-
-            embed = discord.Embed(
-                title='Snippet List',
-                description='Here is a list of snippets you can repond with:\n\n' + ', '.join(tagList),
-            )
-            return await ctx.send(embed=embed)
-
-        doc = db.find_one({'_id': args[0]})
-
     @cog_ext.cog_subcommand(
         base='appeal',
         name='accept',
@@ -676,86 +659,40 @@ class Mail(commands.Cog):
                         },
                     )
 
-        elif (
-            message.channel.type == discord.ChannelType.text
-            and not ctx.guild.get_role(config.modRole) in message.author.roles
-        ):
-            # Regex to match pings with text content after, and none before. Groups: ping id, text content
-            match = re.search(r'^\s*<@!?(\d{15,})>\s+(\S(?:.|\n|\r)+)$', message.content)
+    async def on_command_error(self, ctx: commands.Context, error: commands.CommandError):
+        if ctx.command:
+            cmd_str = ctx.command.full_parent_name + ' ' + ctx.command.name if ctx.command.parent else ctx.command.name
+        else:
+            cmd_str = None
 
-            if match and int(match.group(1)) == self.bot.user.id:
-                await message.delete()
+        if isinstance(error, commands.MissingRequiredArgument):
+            return await ctx.send(
+                f'{config.redTick} Missing one or more required arguments. See `{ctx.prefix}help {cmd_str}`',
+                delete_after=15,
+            )
 
-                db = mclient.modmail.logs
-                thread = db.find_one({'recipient.id': str(message.author.id), 'open': True})
-                content = match.group(2)
+        elif isinstance(error, commands.BadArgument):
+            return await ctx.send(
+                f'{config.redTick} One or more provided arguments are invalid. See `{ctx.prefix}help {cmd_str}`',
+                delete_after=15,
+            )
 
-                embed = discord.Embed(title='New modmail mention', description=content, color=0x7289DA)
-                embed.set_author(name=f'{message.author} ({message.author.id})', icon_url=message.author.avatar_url)
-                embed.set_footer(text=f'{message.channel.id}/{message.id}')
-                embed.add_field(
-                    name=f'Mentioned in', value=f'<#{message.channel.id}> ([Jump to context]({message.jump_url}))'
-                )
+        elif isinstance(error, commands.CheckFailure):
+            return await ctx.send(f'{config.redTick} You do not have permission to run this command', delete_after=15)
 
-                try:
-                    dm_embed = discord.Embed(description=content, color=0x7289DA)
-                    dm_embed.set_author(name=f'{message.author}', icon_url=message.author.avatar_url)
-                    dm_message = await message.author.send(
-                        f'You mentioned {self.bot.user.name} in <#{message.channel.id}>', embed=dm_embed
-                    )
-                    await dm_message.add_reaction('✅')  # We don't need to do this but it matches the design language
+        elif isinstance(error, commands.CommandNotFound):
+            return await ctx.send(
+                f'{config.redTick} Invalid command. If you are trying to open a modmail, please send me a DM to begin',
+                delete_after=15,
+            )
 
-                except (discord.HTTPException, discord.Forbidden, discord.NotFound):
-                    await self.bot.get_channel(config.adminChannel).send(
-                        f'Cannot create thread for mention from <@{message.author.id}> (failed to send DM)', embed=embed
-                    )
-                    await message.channel.send(
-                        f'<@{message.author.id}> You must open your DMs to use modmail threads. Moderators may still receive your mention.',
-                        delete_after=30,
-                    )
+        else:
+            await ctx.send(
+                f'{config.redTick} An unknown exception has occured, if this continues to happen contact the developer.',
+                delete_after=15,
+            )
 
-                else:
-                    if thread:
-                        channel = self.bot.get_guild(int(thread['guild_id'])).get_channel(int(thread['channel_id']))
-
-                        if (
-                            thread['_id'] in self.closeQueue.keys()
-                        ):  # Thread close was scheduled, cancel due to response
-                            self.closeQueue[thread['_id']].cancel()
-                            self.closeQueue.pop(thread['_id'], None)
-                            await channel.send('Thread closure has been canceled because the user has sent a message')
-
-                        db.update_one(
-                            {'_id': thread['_id']},
-                            {
-                                '$push': {
-                                    'messages': {
-                                        'timestamp': str(message.created_at),
-                                        'message_id': str(message.id),
-                                        'content': message.content,
-                                        'type': 'mention',
-                                        'author': {
-                                            'id': str(message.author.id),
-                                            'name': message.author.name,
-                                            'discriminator': message.author.discriminator,
-                                            'avatar_url': str(
-                                                message.author.avatar_url_as(static_format='png', size=1024)
-                                            ),
-                                            'mod': False,
-                                        },
-                                        'attachments': attachments,
-                                        'channel': {'id': message.channel.id, 'name': message.channel.name},
-                                    }
-                                }
-                            },
-                        )
-
-                    else:
-                        channel = await utils._trigger_create_thread(
-                            self.bot, message.author, message, 'user', is_mention=True
-                        )
-
-                    await channel.send(embed=embed)
+            raise error
 
 
 bot.add_cog(Mail(bot))


### PR DESCRIPTION
Replace broken mention function, replace with on_command_error().

The mention function was rendered broken when the command prefix was
changed to use pings of the bots. Considering these function was rarely
(if ever used), it has been removed. In it's place, I added a
on_command_error() function, that returns the following on
CommandNotFound:
"{config.redTick} Invalid command. If you are trying to open a modmail,
please send me a DM to begin",

The snippets command/function was also removed because it remains
unimplemented and unfinshed, leading to user confusion and orphan
code.
